### PR TITLE
Fix for Chrome error

### DIFF
--- a/ControllerBluetoothInterface.js
+++ b/ControllerBluetoothInterface.js
@@ -83,7 +83,7 @@ class ControllerBluetoothInterface {
         ) & 0x3FF;
 
         // com.samsung.android.app.vr.input.service/ui/c.class:L222
-        const timestamp = ((new Int32Array(buffer.slice(0, 4))[0]) & 0xFFFFFFFF) / 1000 * ControllerBluetoothInterface.TIMESTAMP_FACTOR;
+        const timestamp = ((new Int32Array(buffer.slice(0, 3))[0]) & 0xFFFFFFFF) / 1000 * ControllerBluetoothInterface.TIMESTAMP_FACTOR;
 
         // com.samsung.android.app.vr.input.service/ui/c.class:L222
         const temperature = eventData[57];


### PR DESCRIPTION
`Uncaught RangeErrorL byte length of Int32Array should be a multiple of 4`
occurred when trying to slice buffer. 0 to 4 is 5 items. Insert something here about "off by one errors".